### PR TITLE
[#10] Let Attribute Errors allow a check for __exc

### DIFF
--- a/botoflow/data_converter/json_data_converter.py
+++ b/botoflow/data_converter/json_data_converter.py
@@ -205,7 +205,7 @@ def _flow_obj_decoder(dct):
         cls = getattr(module, attr_name)
 
     # if an import error is raised
-    except ImportError:
+    except (ImportError, AttributeError):
         # try and rescue objects with exception information by bundling them
         # into a ImportError
         if '__exc' in dct:


### PR DESCRIPTION
This is based on the assumption that `module = __import__(module_name, globals(), locals(), [attr_name], 0)
        cls = getattr(module, attr_name)` was expected to give an ImportError when the module did not contain the attribute, like the `from-import` statement. But apparently the `__import__` function does not give an error in this case.